### PR TITLE
Expand Promptfoo-style evaluator with assertions and UI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,12 @@ The feature-rich software includes:
 
 **7. Prompt Creation:** A command-line utility lets you create a prompt interactively, adhering to the PGit schema. This feature is currently a proof of concept and is under development for further enhancements.
 
+**8. LiteLLM Evaluation:** The `tools/litellm_multimodel.py` script runs a single prompt against multiple models via [LiteLLM](https://github.com/BerriAI/litellm), enabling quick comparisons similar to Promptfoo.
+
+**9. Promptfoo-style Configs:** The `tools/promptfoo_eval.py` utility processes a Promptfoo-style YAML config to run multiple prompts and test cases across several models. It supports Jinja2 templating, multiple assertion types (exact, contains, regex, etc.), and can export results to JSON.
+
+**10. Web UI:** Launch `tools/promptfoo_ui.py` to view evaluation results in a simple browser-based table, enabling quick visual comparisons of prompt performance across models.
+
 In the ever-growing world of AI, PGit brings a much-needed order to manage language model prompts efficiently. Its features resonate with the industry's demand for traceability and reusability, making it a quintessential tool for anyone dealing with large language models.
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ GitPython==3.1.31
 pyyaml==6.0
 rich==13.4.2
 pandas==2.0.2
+litellm==1.75.2
+jinja2==3.1.2
 

--- a/tools/litellm_multimodel.py
+++ b/tools/litellm_multimodel.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""Run a prompt across multiple models using LiteLLM.
+
+This utility loads a prompt from a PGit YAML file and queries a list of
+models using the LiteLLM library. Results can optionally be written to a
+directory, allowing git-based tracking of model outputs.
+"""
+import argparse
+from pathlib import Path
+
+import yaml
+from git import Repo
+from litellm import completion
+
+
+def run(prompt_file: str, models: list[str], save_dir: str | None = None) -> None:
+    """Execute *prompt_file* against each model in *models*.
+
+    If *save_dir* is provided, a text file per model is written and added to
+    the repository, enabling git-based history of model responses.
+    """
+    with open(prompt_file, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    prompt_text = data.get("prompt", "")
+
+    repo = Repo(Path(prompt_file).resolve().parent, search_parent_directories=True)
+
+    for model in models:
+        resp = completion(model=model, messages=[{"role": "user", "content": prompt_text}])
+        content = resp["choices"][0]["message"]["content"].strip()
+        print(f"\n### {model}\n{content}\n")
+
+        if save_dir:
+            out_dir = Path(save_dir)
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_file = out_dir / f"{Path(prompt_file).stem}_{model.replace('/', '_')}.txt"
+            out_file.write_text(content, encoding="utf-8")
+            repo.git.add(str(out_file))
+            repo.index.commit(f"Add {model} result for {Path(prompt_file).name}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Query multiple models with LiteLLM")
+    parser.add_argument("prompt_file", help="Path to a PGit YAML prompt file")
+    parser.add_argument("models", nargs="+", help="List of model identifiers")
+    parser.add_argument("--save", dest="save_dir", help="Directory to store and commit results")
+    args = parser.parse_args()
+    run(args.prompt_file, args.models, args.save_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/promptfoo_eval.py
+++ b/tools/promptfoo_eval.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+"""Evaluate prompts defined in a Promptfoo-style config using LiteLLM.
+
+Config YAML example::
+
+    models:
+      - openai/gpt-3.5-turbo
+    prompts:
+      - file: prompts/qa/basic.yaml
+    tests:
+      - vars: { animal: cat }
+        assert:
+          - type: equals
+            value: "The capital of France is Paris."
+
+This script loads each prompt, fills variables via Jinja2 templates, queries
+each model using LiteLLM, evaluates the results against a series of simple
+assertions, and prints a table summarizing the outcomes. Results can optionally
+be written to a JSON file for consumption by a small web UI.
+"""
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+from jinja2 import Template
+from litellm import completion
+from rich.console import Console
+from rich.table import Table
+
+
+def load_prompt(file: str) -> str:
+    with open(file, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return data.get("prompt", "")
+
+
+def _run_assert(output: str, assertion: dict[str, Any]) -> bool:
+    """Return True if *output* satisfies *assertion*."""
+    a_type = assertion.get("type", "equals")
+    value = assertion.get("value", "")
+    if a_type == "equals":
+        return output.strip() == value.strip()
+    if a_type == "contains":
+        return value in output
+    if a_type == "regex":
+        return re.search(value, output) is not None
+    if a_type == "startsWith":
+        return output.startswith(value)
+    if a_type == "endsWith":
+        return output.endswith(value)
+    return False
+
+
+def run_evaluation(config_file: str) -> list[dict[str, Any]]:
+    """Evaluate *config_file* and return a list of result dictionaries."""
+    with open(config_file, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+
+    models: list[str] = cfg.get("models", [])
+    prompts: list[dict[str, Any]] = cfg.get("prompts", [])
+    tests: list[dict[str, Any]] = cfg.get("tests", [])
+
+    results = []
+    for prompt_entry in prompts:
+        prompt_file = prompt_entry["file"]
+        template_text = load_prompt(prompt_file)
+        for test in tests:
+            vars_ = test.get("vars", {})
+            tpl = Template(template_text)
+            text = tpl.render(**vars_)
+            assertions: Iterable[dict[str, Any]] = test.get("assert", [])
+            if not assertions and (expected := test.get("expected")) is not None:
+                assertions = [{"type": "equals", "value": expected}]
+            for model in models:
+                resp = completion(model=model, messages=[{"role": "user", "content": text}])
+                output = resp["choices"][0]["message"]["content"].strip()
+                assert_results = [
+                    {"type": a["type"], "value": a.get("value", ""), "pass": _run_assert(output, a)}
+                    for a in assertions
+                ]
+                passed = all(a["pass"] for a in assert_results) if assert_results else None
+                results.append({
+                    "model": model,
+                    "prompt": prompt_file,
+                    "vars": vars_,
+                    "output": output,
+                    "asserts": assert_results,
+                    "pass": passed,
+                })
+    return results
+
+
+def _render_table(results: list[dict[str, Any]]) -> None:
+    table = Table(title="Promptfoo-style evaluation")
+    table.add_column("Model")
+    table.add_column("Prompt")
+    table.add_column("Vars")
+    table.add_column("Output")
+    table.add_column("Checks", overflow="fold")
+    table.add_column("Pass")
+
+    for r in results:
+        checks = ", ".join(
+            f"{a['type']}={a['value']}:{'✅' if a['pass'] else '❌'}" for a in r["asserts"]
+        )
+        table.add_row(
+            r["model"],
+            Path(r["prompt"]).name,
+            ", ".join(f"{k}={v}" for k, v in r["vars"].items()),
+            r["output"],
+            checks,
+            "\u2705" if r["pass"] else ("\u274c" if r["pass"] is False else ""),
+        )
+
+    Console().print(table)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run Promptfoo-style evaluations with LiteLLM"
+    )
+    parser.add_argument("config", help="Path to promptfoo-style YAML config file")
+    parser.add_argument(
+        "--json-out",
+        dest="json_out",
+        help="Optional path to write results JSON",
+    )
+    args = parser.parse_args()
+
+    results = run_evaluation(args.config)
+    _render_table(results)
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as f:
+            json.dump(results, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/promptfoo_ui.py
+++ b/tools/promptfoo_ui.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+"""Serve prompt evaluation results in a simple web UI."""
+import argparse
+from pathlib import Path
+
+from flask import Flask, render_template_string
+
+from promptfoo_eval import run_evaluation
+
+app = Flask(__name__)
+results = []
+
+HTML = """
+<!doctype html>
+<title>PGit Prompt Evaluator</title>
+<h1>PGit Prompt Evaluator</h1>
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr>
+    <th>Model</th><th>Prompt</th><th>Vars</th><th>Output</th><th>Checks</th><th>Pass</th>
+  </tr>
+  {% for r in results %}
+  <tr>
+    <td>{{ r.model }}</td>
+    <td>{{ r.prompt | basename }}</td>
+    <td>{{ r.vars | fmt_vars }}</td>
+    <td style="white-space: pre-wrap">{{ r.output }}</td>
+    <td>
+      <ul>
+      {% for a in r.asserts %}
+        <li>{{ a.type }}={{ a.value }} -> {{ '✅' if a.pass else '❌' }}</li>
+      {% endfor %}
+      </ul>
+    </td>
+    <td>{{ '✅' if r.pass else ('❌' if r.pass is false else '') }}</td>
+  </tr>
+  {% endfor %}
+</table>
+"""
+
+
+@app.template_filter('basename')
+def _basename(path):
+    return Path(path).name
+
+
+@app.template_filter('fmt_vars')
+def _fmt_vars(d):
+    return ", ".join(f"{k}={v}" for k, v in d.items())
+
+
+@app.route("/")
+def index():
+    return render_template_string(HTML, results=results)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Serve evaluation results in a web UI")
+    parser.add_argument("config", help="Path to promptfoo-style YAML config file")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=5000)
+    args = parser.parse_args()
+
+    global results
+    results = run_evaluation(args.config)
+    app.run(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend Promptfoo-style evaluator with Jinja2 templating, multiple assertion types, and optional JSON output
- add Flask-based web UI to display evaluation results
- document new capabilities and add Jinja2 dependency

## Testing
- `pip install -r requirements.txt`
- `python tools/promptfoo_eval.py --help`
- `python tools/promptfoo_ui.py --help`
- `python tools/litellm_multimodel.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6895a00331c48328bde61cca19874718

## Summary by Sourcery

Introduce three new tools for multi-model prompt evaluation: a LiteLLM comparison script, a Promptfoo-style evaluator with templating and assertions, and a Flask web UI; update dependencies and README accordingly

New Features:
- Add a CLI tool to run a prompt across multiple LiteLLM models with optional git-tracked output
- Add a Promptfoo-style evaluator CLI supporting Jinja2 templating, multiple assertion types, and JSON export
- Add a Flask-based web UI to display prompt evaluation results

Build:
- Add litellm and jinja2 to project dependencies

Documentation:
- Update README to document LiteLLM multi-model evaluation, Promptfoo-style configs, and the new web UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a script to compare prompt outputs across multiple models using LiteLLM.
  * Introduced a Promptfoo-style evaluation utility supporting YAML configs, Jinja2 templating, multiple assertion types, and JSON export.
  * Added a web UI to visually display and compare prompt evaluation results in a browser.

* **Documentation**
  * Updated the README to include descriptions of the new evaluation tools and web UI.

* **Chores**
  * Added new dependencies: `litellm` and `jinja2` to requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->